### PR TITLE
fix: Incorrect syntax for redirect causing inconsistent results

### DIFF
--- a/lib/server/ssrMiddleware.tsx
+++ b/lib/server/ssrMiddleware.tsx
@@ -143,9 +143,8 @@ export function getSSRMiddleware(parameters: {
             .subscribe({
                 next: ({ html, status, redirect }) => {
                     if (redirect) {
-                        res.status(status)
-                            .redirect(redirect)
-                            .send();
+                        console.error(`Redirect triggered:`, `${redirect}[${status}]`);
+                        res.redirect(status, redirect);
                     } else {
                         res.status(status);
                         res.send(`<!doctype html>\n${html}`);


### PR DESCRIPTION
### Feature/Issue Description

- Running server in production SSR redirects are failing

### Code Explanation

- Incorrect syntax for redirect(). Status and Send are omitted. Status is passed as first argument.

### Issues / Caveats

None